### PR TITLE
Remove widgets by definition id

### DIFF
--- a/src/scripts/directives/adf-widget.directive.js
+++ b/src/scripts/directives/adf-widget.directive.js
@@ -133,7 +133,7 @@ angular.module('adf')
         var deleteWidget = function() {
           var column = $scope.col;
           if (column) {
-            var index = column.widgets.indexOf(definition);
+            var index = column.widgets.map(function(x) { return x.wid; }).indexOf(definition.wid);
             if (index >= 0) {
               column.widgets.splice(index, 1);
             }


### PR DESCRIPTION
This fixes an edge type use case where someone editing a dashboard adds multiple of the same widget within the same column. Once removed, it doesn't find an index in subsequent removals of the same widget type, but it does remove it from the dashboard. As a result, the visual state of the widgets in a column differs (visual state removes widgets) from the object (subsequent widgets of the same type stay in the column after the first removal), unless using the widget id to identify a unique entry.